### PR TITLE
Add a CLI utility for extracting cnxml metadata to json

### DIFF
--- a/cnxml/cli.py
+++ b/cnxml/cli.py
@@ -5,9 +5,12 @@ Validates CNXML and COLLXML
 """
 from __future__ import print_function
 import argparse
+import json
+from lxml import etree
 from pathlib import Path
 
 from .validation import validate_cnxml, validate_collxml
+from .parse import parse_metadata
 
 
 def _format_error_line(error):
@@ -50,3 +53,18 @@ def collxml(argv=None):
 
     retcode = errors and 1 or 0
     return retcode
+
+
+def extract_metadata(argv=None):
+    args = _arg_parser().parse_args(argv)
+
+    files = [Path(x) for x in args.xml]
+
+    data = []
+    for file in files:
+        with file.open('rb') as fb:
+            xml = etree.parse(fb)
+        metadata = parse_metadata(xml)
+        data.append(metadata)
+    print(json.dumps(data, sort_keys=True, indent=2))
+    return 0

--- a/cnxml/tests/test_cli.py
+++ b/cnxml/tests/test_cli.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from cnxml.cli import cnxml, collxml
+from cnxml.cli import cnxml, collxml, extract_metadata
 
 
 def test_valid_cnxml(capsys, datadir):
@@ -51,3 +51,18 @@ def test_invalid_collxml(capsys, datadir):
     assert out.splitlines() == expected_out_lines
     assert err == ''
     assert retcode == 1
+
+
+def test_extract_metadata(capsys, datadir):
+    file_one = str(datadir / 'valid_collection.xml')
+    file_two = str(datadir / 'valid.cnxml')
+
+    retcode = extract_metadata([file_one, file_two])
+    assert retcode == 0
+
+    # Check for json output
+    out, err = capsys.readouterr()
+    assert out.startswith('[\n  {\n    "abstract": "This introductory, algebra-based,')
+    # Check for the dashes that separate the individual files output
+    assert '    "version": "1.9"\n  },\n' in out
+    assert out.endswith('    "version": "1.12"\n  }\n]\n')

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
     [console_scripts]
     validate-cnxml = cnxml.cli:cnxml
     validate-collxml = cnxml.cli:collxml
+    extract-cnxml-metadata = cnxml.cli:extract_metadata
     """,
     )


### PR DESCRIPTION
Example usage and output:

```
$ extract-cnxml-metadata cnxml/tests/data/valid_collection.xml cnxml/tests/data/valid.cnxml
[
  {
    "abstract": "This introductory, algebra-based, two-semester college physics book is grounded with real-world examples, illustrations, and explanations to help students grasp key, fundamental physics concepts. This online, fully editable and customizable title includes learning objectives, concept questions, links to labs and simulations, and ample practice opportunities to solve traditional physics application problems.",
    "authors": [
      "OpenStaxCollege"
    ],
    "created": "2012/01/23 13:03:30.293 US/Central",
    "id": "col11406",
...
    "title": "College Physics",
    "version": "1.9"
  },
  {
    "abstract": "<list>\n<item>Identify and explain the properties of a projectile, such as acceleration due to gravity, range, maximum height, and trajectory.</item>\n<item>Determine the location and velocity of a projectile at different points in its trajectory.</item>\n<item>Apply the principle of independence of motion to solve projectile motion problems.</item>\n</list>",
    "authors": [
      "OpenStaxCollege"
    ],
    "created": "2011/12/21 11:28:12 -0600",
    "id": "m42042",
...
    "title": "Projectile Motion",
    "version": "1.12"
  }
]
```