### PR TITLE
Relax required information when parsing metadata

### DIFF
--- a/cnxml/jing.py
+++ b/cnxml/jing.py
@@ -40,7 +40,7 @@ def _parse_jing_output(output):
 
     """
     output = output.strip()
-    values = [_parse_jing_line(l) for l in output.split('\n') if l]
+    values = [_parse_jing_line(line) for line in output.split('\n') if line]
     return tuple(values)
 
 

--- a/cnxml/parse.py
+++ b/cnxml/parse.py
@@ -71,16 +71,18 @@ def parse_metadata(elm_tree):
 
     """
     xpath = make_cnx_xpath(elm_tree)
-    role_xpath = lambda xp: tuple(xpath(xp)[0].split())  # noqa: E731
+    role_xpath = lambda xp: tuple(  # noqa: E731
+        (_maybe(xpath(xp)) or "").split()
+    )
 
     props = {
         'id': _maybe(xpath('//md:content-id/text()')),
-        'version': xpath('//md:version/text()')[0],
-        'created': xpath('//md:created/text()')[0],
-        'revised': xpath('//md:revised/text()')[0],
-        'title': xpath('//md:title/text()')[0],
-        'license_url': xpath('//md:license/@url')[0],
-        'language': xpath('//md:language/text()')[0],
+        'version': _maybe(xpath('//md:version/text()')),
+        'created': _maybe(xpath('//md:created/text()')),
+        'revised': _maybe(xpath('//md:revised/text()')),
+        'title': _maybe(xpath('//md:title/text()')),
+        'license_url': _maybe(xpath('//md:license/@url')),
+        'language': _maybe(xpath('//md:language/text()')),
         'authors': role_xpath('//md:role[@type="author"]/text()'),
         'maintainers': role_xpath('//md:role[@type="maintainer"]/text()'),
         'licensors': role_xpath('//md:role[@type="licensor"]/text()'),

--- a/cnxml/parse.py
+++ b/cnxml/parse.py
@@ -30,10 +30,10 @@ NSMAP = {
 }
 
 
-def _maybe(l):
+def _maybe(vals):
     """Grab the first value if it exists."""
     try:
-        return l[0]
+        return vals[0]
     except IndexError:
         return None
 

--- a/cnxml/tests/test_parse.py
+++ b/cnxml/tests/test_parse.py
@@ -111,3 +111,38 @@ def test_parse_derived_from(xml):
     assert props['derived_from'] == expected
     # Verify we've discovered the correct title
     assert props['title'] == 'College Physics'
+
+
+def test_parse_with_minimal_metadata():
+    cnxml = """
+        <document xmlns="http://cnx.rice.edu/cnxml">
+            <metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+                <md:content-id>col11406</md:content-id>
+                <md:title>College Physics</md:title>
+                <md:abstract/>
+            </metadata>
+        </document>
+    """
+
+    xml = etree.fromstring(cnxml)
+    props = parse_metadata(xml)
+
+    expected_props = {
+        'abstract': '',
+        'authors': (),
+        'created': None,
+        'derived_from': {'title': None, 'uri': None},
+        'id': 'col11406',
+        'keywords': (),
+        'language': None,
+        'license_url': None,
+        'licensors': (),
+        'maintainers': (),
+        'print_style': None,
+        'revised': None,
+        'subjects': (),
+        'title': 'College Physics',
+        'version': None,
+    }
+    # Verify the metadata
+    assert props == expected_props

--- a/cnxml/tests/test_validation.py
+++ b/cnxml/tests/test_validation.py
@@ -21,7 +21,7 @@ def test_cnxml_validation_messages(datadir):
         [str(datafile), '67', '11', 'error', 'element "para" missing required attribute "id"']
     )
     errors = validate_cnxml(datafile)
-    assert tuple(list(l) for l in errors) == expected
+    assert tuple(list(error) for error in errors) == expected
 
 
 def test_cnxml_multiple_validation_messages(datadir):
@@ -33,7 +33,7 @@ def test_cnxml_multiple_validation_messages(datadir):
         [str(bad_datafile), '67', '11', 'error', 'element "para" missing required attribute "id"']
     )
     errors = validate_cnxml(good_datafile, bad_datafile)
-    assert tuple(list(l) for l in errors) == expected
+    assert tuple(list(error) for error in errors) == expected
 
 
 def test_validate_collxml(datadir):
@@ -52,7 +52,7 @@ def test_collxml_validation_messages(datadir):
     )
 
     errors = validate_collxml(datafile)
-    assert tuple(list(l) for l in errors) == expected
+    assert tuple(list(error) for error in errors) == expected
 
 
 def test_valid_derived_from_cnxml(datadir):
@@ -79,4 +79,4 @@ def test_invalid_derived_from_cnxml(datadir):
     )
 
     errors = validate_cnxml(filepath)
-    assert tuple(list(l) for l in errors) == expected
+    assert tuple(list(error) for error in errors) == expected


### PR DESCRIPTION
The `parse_metadata` function resulted in errors when invoked during
neb assemble with CNXML files that contain a minimal set of metadata.
This change therefore relaxes some of the implicit assumptions around
metadata that must be available for the function to process
successfully.