### PR TITLE
Require md:language for collxml but not cnxml

### DIFF
--- a/cnxml/tests/data/valid_git_collection.xml
+++ b/cnxml/tests/data/valid_git_collection.xml
@@ -17,7 +17,7 @@
          Changes to the metadata section in the source will not be saved. -->
     <md:content-id>col11406</md:content-id>
     <md:title>College Physics</md:title>
-
+    <md:language>en</md:language>
     <md:license url="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License 4.0</md:license>
     <md:uuid>e1edc39a-14cd-4d61-886f-36bebd27e2d2</md:uuid>
     <md:slug>college-physics</md:slug>

--- a/cnxml/tests/test_parse.py
+++ b/cnxml/tests/test_parse.py
@@ -71,7 +71,7 @@ def test_git_parse(git_xml):
         'derived_from': {'title': None, 'uri': None},
         'id': 'col11406',
         'keywords': (),
-        'language': None,
+        'language': 'en',
         'license_url': 'http://creativecommons.org/licenses/by/4.0/',
         'licensors': (),
         'maintainers': (),

--- a/cnxml/xml/cnxml/schema/rng/0.7/cnxml-common-jing.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.7/cnxml-common-jing.rng
@@ -75,7 +75,12 @@
 
   <include href="cnxml-defs.rng">
     <define name="metadata-content">
-      <ref name="mdml-metadata-content"/>
+      <interleave>
+        <ref name="mdml-metadata-content"/>
+        <optional>
+          <ref name="mdml-language"/>
+        </optional>
+      </interleave>
     </define>
     <define name="content-content">
       <choice>

--- a/cnxml/xml/cnxml/schema/rng/0.7/cnxml-common.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.7/cnxml-common.rng
@@ -73,7 +73,12 @@
 
   <include href="cnxml-defs.rng">
     <define name="metadata-content">
-      <ref name="mdml-metadata-content"/>
+      <interleave>
+        <ref name="mdml-metadata-content"/>
+        <optional>
+          <ref name="mdml-language"/>
+        </optional>
+      </interleave>
     </define>
     <define name="content-content">
       <choice>

--- a/cnxml/xml/collxml/schema/rng/2.0/collxml-defs.rng
+++ b/cnxml/xml/collxml/schema/rng/2.0/collxml-defs.rng
@@ -170,7 +170,10 @@
       <optional>
         <ref name="mdml-mdml-version-attribute"/>
       </optional>
-      <ref name="mdml-metadata-content"/>
+      <interleave>
+        <ref name="mdml-metadata-content"/>
+        <ref name="mdml-language"/>
+      </interleave>
     </element>
   </define>
 

--- a/cnxml/xml/mdml/schema/rng/0.5/mdml-defs.rng
+++ b/cnxml/xml/mdml/schema/rng/0.5/mdml-defs.rng
@@ -67,9 +67,6 @@
         <ref name="mdml-abstract"/>
       </optional>
       <optional>
-        <ref name="mdml-language"/>
-      </optional>
-      <optional>
         <ref name="mdml-objectives"/>
       </optional>
       <optional>
@@ -101,6 +98,9 @@
       <ref name="mdml-mdml-version-attribute"/>
       <ref name="mdml-common-attributes"/>
       <ref name="mdml-metadata-content"/>
+      <optional>
+        <ref name="mdml-language"/>
+      </optional>
     </element>
   </define>
 
@@ -446,6 +446,9 @@
       <ref name="mdml-derived-from-attributes"/>
       <zeroOrMore>
         <ref name="mdml-metadata-content"/>
+        <optional>
+          <ref name="mdml-language"/>
+        </optional>
       </zeroOrMore>
     </element>
   </define>


### PR DESCRIPTION
This change removes language from the shared `mdml-metadata-content` so that it can be defined as optional or required in a specific context (e.g. in `collxml` vs `cnxml`). 