### PR TITLE
Update cnxml.parse so empty license_url is same as None

### DIFF
--- a/cnxml/parse.py
+++ b/cnxml/parse.py
@@ -88,6 +88,8 @@ def lookup_license_text(license_url):
             'Creative Commons Attribution License',
         'http://creativecommons.org/licenses/by-nc-sa/4.0':
             'Creative Commons Attribution-NonCommercial-ShareAlike License',
+        'https://creativecommons.org/licenses/by/4.0/deed.pl':
+            'Uznanie autorstwa (CC BY)'
     }
     # If license_url is None or empty, appropriately return None
     if license_url is None or license_url.strip() == '':

--- a/cnxml/parse.py
+++ b/cnxml/parse.py
@@ -89,13 +89,13 @@ def lookup_license_text(license_url):
         'http://creativecommons.org/licenses/by-nc-sa/4.0':
             'Creative Commons Attribution-NonCommercial-ShareAlike License',
     }
-    # If license_url is None, appropriately return None
-    if license_url is None:
+    # If license_url is None or empty, appropriately return None
+    if license_url is None or license_url.strip() == '':
         return None
-    # If license_url is not None, we expect to return a value
     license_text = switcher.get(license_url.rstrip('/'), None)
+    # At this point, we expect to return a value
     if license_text is None:
-        raise Exception(f'Invalid license url {license_url}')
+        raise Exception(f'Invalid license url: "{license_url}"')
     return license_text
 
 


### PR DESCRIPTION
This is in reference to openstax/ce#1860 [Update cnxml.parse to handle empty license urls](https://github.com/openstax/ce/issues/1860)

## Example:
<md:license url=""/>

### Before
Raised exception indicating Invalid license url

### After
Returns None

### Rationale 
A license element with an empty url attribute means the same thing as not having a license element at all; therefore, we should handle these situations the the same way.

This would cause `neb assemble` to use the default license when an empty license url is given.

