### PR TITLE
1860 default license text AND url

### DIFF
--- a/cnxml/parse.py
+++ b/cnxml/parse.py
@@ -123,7 +123,7 @@ def _parse_license(license_el):
     if(typ not in license_info_map or
             ver not in license_info_map[typ]['versions']):
         raise Exception('Unknown license type or version: ' +
-                        f'{{ type: "{typ}", version: "{ver}" }}')
+                        f'{{ url: "{url}", type: "{typ}", version: "{ver}" }}')
     if is_localized:
         # In this instance, use the text in the element. Hopefully this text
         # has been translated. We could store translated versions of license

--- a/cnxml/parse.py
+++ b/cnxml/parse.py
@@ -87,6 +87,8 @@ def _parse_license(license_el):
         'by-nd-nc': {
             'text': 'Creative Commons Attribution-NoDerivs-NonCommercial' +
                     ' License',
+            # TODO: by-nd-nc version 1.0 does not exist, remove when we
+            #       know it is safe
             'versions': ['1.0', '2.0']
         },
         'by-sa': {
@@ -113,7 +115,7 @@ def _parse_license(license_el):
         if is_localized else
         url.rstrip('/')  # ignore trailing '/'
     ).split('/')[-2:]
-    if len(type_and_version) != 2:
+    if len(type_and_version) != 2 or 'creativecommons.org' not in url:
         raise Exception(f'Invalid license url: "{url}"')
     typ, ver = type_and_version
     # Even if the license is localized, it should have a valid type and

--- a/cnxml/tests/test_parse.py
+++ b/cnxml/tests/test_parse.py
@@ -236,10 +236,10 @@ def test_parse_with_optional_metadata():
 @pytest.mark.parametrize(
     'license_el',
     [
-        ('<md:license url=""/>',),
-        ('<md:license url="  "/>',),
-        ('<md:license/>',),
-        ('',),
+        '<md:license url=""/>',
+        '<md:license url="  "/>',
+        '<md:license/>',
+        ''
     ]
 )
 def test_parse_no_license_url_returns_default(license_el):
@@ -267,6 +267,68 @@ def test_parse_no_license_url_returns_default(license_el):
         'language': None,
         'license_url': DEFAULT_LICENSE_URL,
         'license_text': DEFAULT_LICENSE_TEXT,
+        'licensors': (),
+        'maintainers': (),
+        'print_style': None,
+        'revised': None,
+        'subjects': (),
+        'title': 'College Physics',
+        'version': None,
+        'uuid': None,
+        'canonical_book_uuid': None,
+        'slug': None,
+    }
+    # Verify the metadata
+    assert props == expected_props
+
+
+@pytest.mark.parametrize(
+    'license_url,license_text',
+    [
+        (
+            'http://creativecommons.org/licenses/by/4.0/',
+            'Creative Commons Attribution License'
+        ),
+        (
+            'http://creativecommons.org/licenses/by/2.0/',
+            'Creative Commons Attribution License'
+        ),
+        (
+            'http://creativecommons.org/licenses/by-nd/2.0/',
+            'Creative Commons Attribution-NoDerivs License'
+        ),
+        (
+            # Spaces should be ignored
+            ' http://creativecommons.org/licenses/by-nc-sa/4.0/ ',
+            'Creative Commons Attribution-NonCommercial-ShareAlike License'
+        )
+    ]
+)
+def test_parse_license_url_returns_expected_value(license_url, license_text):
+    cnxml = f"""
+        <document xmlns="http://cnx.rice.edu/cnxml">
+            <title>College Physics</title>
+            <metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+                <md:content-id>col11406</md:content-id>
+                <md:abstract/>
+                <md:license url="{license_url}"/>
+            </metadata>
+        </document>
+    """
+
+    xml = etree.fromstring(cnxml)
+    props = parse_metadata(xml)
+
+    expected_props = {
+        'abstract': '',
+        'authors': (),
+        'created': None,
+        'derived_from': {'title': None, 'uri': None},
+        'id': 'col11406',
+        'keywords': (),
+        'language': None,
+        'license_url': license_url.strip(),
+        'license_text': license_text,
         'licensors': (),
         'maintainers': (),
         'print_style': None,
@@ -342,8 +404,8 @@ def test_parse_localized_license_url_returns_element_text(license_url, license_t
 @pytest.mark.parametrize(
     'license_el',
     [
-        ('<md:license url="creativecommons.org/licenses/by/4.0/deed.xx">   </md:license>',),
-        ('<md:license url="creativecommons.org/licenses/by/4.0/deed.xx"/>',)
+        '<md:license url="creativecommons.org/licenses/by/4.0/deed.xx">   </md:license>',
+        '<md:license url="creativecommons.org/licenses/by/4.0/deed.xx"/>'
     ]
 )
 def test_parse_localized_license_with_no_license_text_should_error(license_el):
@@ -369,13 +431,11 @@ def test_parse_localized_license_with_no_license_text_should_error(license_el):
     'license_url',
     [
         # Bad type
-        ('https://creativecommons.org/licenses/by-sad/4.0/deed.xx',),
+        'https://creativecommons.org/licenses/by-sad/4.0/deed.xx',
         # Bad type
-        ('https://creativecommons.org/licenses/by-something-else/4.0/',),
+        'https://creativecommons.org/licenses/by-something-else/4.0/',
         # Bad version
-        ('https://creativecommons.org/licenses/by/999.0/',),
-        # Bad
-        ('a/b/c/d/e/f/g',)
+        'https://creativecommons.org/licenses/by/999.0/'
     ]
 )
 def test_parse_license_url_with_typo_should_error(license_url):
@@ -400,9 +460,13 @@ def test_parse_license_url_with_typo_should_error(license_url):
 @pytest.mark.parametrize(
     'license_url',
     [
-        ('this-is-a-bad-url',),
-        ('/deed.xx',),
-        ('deed.xx',),
+        'this-is-a-bad-url',
+        '/deed.xx',
+        'deed.xx',
+        # Valid, but not a license url
+        'http://www.example.com/by/4.0/',
+        # Bad
+        'a/b/c/d/e/f/g'
     ]
 )
 def test_parse_license_with_bad_url_should_error(license_url):


### PR DESCRIPTION
### Localization
My goal was to make license parsing more maintainable. One problem with the old license parsing was that it required each license version to be present in a dictionary. This became problematic when a Polish license (ending in deed.pl) was used. We had to manually add this license into our dictionary.

I tried to address this by using the text content of the license element if the url ends in '/deed.*' (i.e. localized urls). 

### Validation
In any case, we would like to know that the license url used is valid. This new validation is more granular and yields clearer error messages. Even though localized license urls result in the license element's text content being used as `license_text`, these urls still undergo the same validation as non-localized urls.

### `None` shall not pass (for `license_text` or `license_url`) 
`license_text` and `license_url` cannot be `None` anymore: if no license url is available, these properties default to `'Creative Commons Attribution License (ASSUMED)'` and `'http://creativecommons.org/licenses/by/4.0/'`, respectively. This should fix some edge cases involving user books. Overall, however, this fallback should be utilized rarely.