### PR TITLE
Fixup: Remove default license; return None, like before.

### DIFF
--- a/cnxml/parse.py
+++ b/cnxml/parse.py
@@ -30,8 +30,6 @@ NSMAP = {
 }
 
 
-DEFAULT_LICENSE_TEXT = 'Creative Commons Attribution License (ASSUMED)'
-DEFAULT_LICENSE_URL = 'http://creativecommons.org/licenses/by/4.0/'
 LICENSE_INFO_MAP = {
     'by': {
         'text': 'Creative Commons Attribution License',
@@ -117,15 +115,15 @@ def _parse_license_url(url):
 
 
 def _parse_license(license_el, language):
-    default_license = (DEFAULT_LICENSE_TEXT, DEFAULT_LICENSE_URL)
-    if license_el is None:
-        return default_license
-    url = license_el.attrib.get('url', None)
+    url = None
+    if license_el is not None:
+        url = license_el.attrib.get('url', None)
+        if url is not None:
+            url = url.strip()
+            if len(url) == 0:
+                url = None
     if url is None:
-        return default_license
-    url = url.strip()
-    if len(url) == 0:
-        return default_license
+        return (None, None)
 
     typ, ver, license_lang = _parse_license_url(url)
     if license_lang is not None and license_lang != 'en':

--- a/cnxml/tests/test_parse.py
+++ b/cnxml/tests/test_parse.py
@@ -1,7 +1,7 @@
 import pytest
 from lxml import etree
 
-from cnxml.parse import NSMAP, parse_metadata, DEFAULT_LICENSE_TEXT, DEFAULT_LICENSE_URL
+from cnxml.parse import NSMAP, parse_metadata
 
 
 @pytest.fixture
@@ -175,8 +175,8 @@ def test_parse_with_minimal_metadata():
         'id': 'col11406',
         'keywords': (),
         'language': None,
-        'license_url': DEFAULT_LICENSE_URL,
-        'license_text': DEFAULT_LICENSE_TEXT,
+        'license_url': None,
+        'license_text': None,
         'licensors': (),
         'maintainers': (),
         'print_style': None,
@@ -216,8 +216,8 @@ def test_parse_with_optional_metadata():
         'id': 'col11406',
         'keywords': (),
         'language': None,
-        'license_url': DEFAULT_LICENSE_URL,
-        'license_text': DEFAULT_LICENSE_TEXT,
+        'license_url': None,
+        'license_text': None,
         'licensors': (),
         'maintainers': (),
         'print_style': None,
@@ -265,8 +265,8 @@ def test_parse_no_license_url_returns_default(license_el):
         'id': 'col11406',
         'keywords': (),
         'language': None,
-        'license_url': DEFAULT_LICENSE_URL,
-        'license_text': DEFAULT_LICENSE_TEXT,
+        'license_url': None,
+        'license_text': None,
         'licensors': (),
         'maintainers': (),
         'print_style': None,

--- a/cnxml/tests/test_parse.py
+++ b/cnxml/tests/test_parse.py
@@ -292,6 +292,17 @@ def test_parse_no_license_url_returns_default(license_el):
             'en'
         ),
         (
+            # https should work too
+            'https://creativecommons.org/licenses/by/4.0/deed.en',
+            'Creative Commons Attribution License',
+            'en'
+        ),
+        (
+            'https://creativecommons.org/licenses/by/4.0',
+            'Creative Commons Attribution License',
+            'en'
+        ),
+        (
             'http://creativecommons.org/licenses/by/2.0/',
             'Creative Commons Attribution License',
             'pl'


### PR DESCRIPTION
~This is intended to be merged after user books are no longer a problem.~ We decided that it would be better to make one-off scripts that will update user content to comply with our current standards.

This PR removes the default license and makes parse_license return `None` for `license_text` and `None` for `license_url`, as it did in the past, when:
1. `md:license` is missing
2. `md:license` does not have a `url` attribute
3. `md:license` has an empty `url` attribute

The changes to license text parsing, however, remain. See #56 for a full review of those changes.