### PR TITLE
1985 Update poet schema - make table summary optional...

### DIFF
--- a/cnxml/xml/cnxml/schema/rng/0.7/cnxml-defs.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.7/cnxml-defs.rng
@@ -2102,7 +2102,7 @@
         <attribute name="summary"/>
       </optional>
       <optional>
-        <attribute name="screenreader-table-description"/>
+        <attribute name="aria-label"/>
       </optional>
       <ref name="colsep-attribute"/>
       <ref name="rowsep-attribute"/>

--- a/cnxml/xml/cnxml/schema/rng/0.7/cnxml-defs.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.7/cnxml-defs.rng
@@ -2098,7 +2098,12 @@
           </choice>
         </attribute>
       </optional>
-      <attribute name="summary"/>
+      <optional>
+        <attribute name="summary"/>
+      </optional>
+      <optional>
+        <attribute name="screenreader-table-description"/>
+      </optional>
       <ref name="colsep-attribute"/>
       <ref name="rowsep-attribute"/>
       <ref name="table.att"/>


### PR DESCRIPTION
- [x] openstax/ce#1985

For more details, see:
- openstax/poet#153

---

Update poet schema - make table summary optional and add screenreader-table-description attribute which is also optional.

**Note:** I am not sure if this change should be applied to the master branch as well, or if it is better to wait for the more permanent. If it should be applied to master as well, I will open a separate PR for that.