### PR TITLE
Make content-id optional

### DIFF
--- a/cnxml/xml/mdml/schema/rng/0.5/mdml-defs.rng
+++ b/cnxml/xml/mdml/schema/rng/0.5/mdml-defs.rng
@@ -14,7 +14,9 @@
 
   <define name="mdml-metadata-content">
     <interleave>
-      <ref name="mdml-content-id"/>
+      <optional>
+        <ref name="mdml-content-id"/>
+      </optional>
       <optional>
         <ref name="mdml-repository"/>
       </optional>


### PR DESCRIPTION
Note: This will also make the element optional in **modules**, but the schema patch in poet overwrites this to make it required in modules.

Here's a screenshot to illustrate that POET still complains about missing content-id in a module, but validate-cnxml does not.
<img width="1610" alt="Screen Shot 2023-03-15 at 1 41 29 PM" src="https://user-images.githubusercontent.com/33585550/225411621-20e19dd7-b943-480b-b2fd-7a2e8e02f947.png">
